### PR TITLE
Upgraded ktlint to 0.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ configurations {
 }
 
 dependencies {
-    ktlint 'com.github.shyiko:ktlint:0.7.0'
+    ktlint 'com.github.shyiko:ktlint:0.8.1'
 }
 
 task ktlint(type: JavaExec) {


### PR DESCRIPTION
no-unit-return and modifier-order rules where not enabled in [0.7.0](https://github.com/shyiko/ktlint/blob/master/CHANGELOG.md#fixed-1) (by mistake). This is why [src/main/kotlin/com/hadihariri/kotlin/inspections/Main.kt](https://github.com/hhariri/kotlin-inspections/blob/master/src/main/kotlin/com/hadihariri/kotlin/inspections/Main.kt#L7):7 wasn't tripping over `Unnecessary "Unit" return type`. It's all fixed in 0.8.1. Sorry for inconvenience.